### PR TITLE
handle break in conditions

### DIFF
--- a/src/otest/aus/tool.py
+++ b/src/otest/aus/tool.py
@@ -110,7 +110,7 @@ class Tester(tool.Tester):
                 if self.conv.flow["assert"]:
                     _ver = Verify(self.check_factory, self.conv)
                     _ver.test_sequence(self.conv.flow["assert"])
-            except KeyError:
+            except (KeyError, Break):
                 self.conv.events.store(EV_CONDITION, State('Done', status=OK))
             except ConditionError:
                 pass


### PR DESCRIPTION
don't return an HTTP error 500 upon encountering a Break exception in
the conditions handling phase but finish the flow and display the error
in the test logs; addresses openid-certification/oidctest#77

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>