### PR TITLE
add response mode and response type categories to conf_setup.py

### DIFF
--- a/src/otest/conf_setup.py
+++ b/src/otest/conf_setup.py
@@ -41,6 +41,8 @@ RP_ORDER = [
 
 OP_ORDER = [
     "Response Type & Response Mode",
+    "Response Type",
+    "Response Mode",
     "Discovery",
     "Dynamic Client Registration",
     "redirect_uri",


### PR DESCRIPTION
Prep response mode and response type categories for display. See https://github.com/openid-certification/oidctest/issues/101#issue-328278453

Empty categories don't show up.